### PR TITLE
Changed namespace - Fixing conflicts with UnityEngine.Gizmos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ public class GizmoDrawer : MonoBehaviour
         //use custom material, if null it uses a default line material
         Gizmos.Material = material;
         
-        //toggle gizmo drawing using the same key as in minecwaft
+        //toggle gizmo drawing using the same key as in minecraft
         if (Input.GetKeyDown(KeyCode.F3))
         {
             Gizmos.Enabled = !Gizmos.Enabled;
@@ -52,7 +52,7 @@ The ability to add custom drawers is possible. Inherit from the `Drawer` class a
 - Circle = Can be used to draw spheres as well.
 
 ## Notes
-The package uses the same class name as the built-in gizmo class, if you'd like to specify the built-in one, explictly call `UntiyEngine.Gizmos.X()`. On the other hand, you can also point to this package's gizmo class with `global::Gizmos`. The reason why its named the same, is so that it's quicker to rewrite all the method calls, and to mimize the amount of used namespaces to declare at the top of the class file.
+The package uses the same class name as the built-in gizmo class, if you'd like to specify the built-in one, explictly call `UnityEngine.Gizmos.X()`. On the other hand, you can also point to this package's gizmo class with `global::Gizmos`. The reason why its named the same, is so that it's quicker to rewrite all the method calls, and to mimize the amount of used namespaces to declare at the top of the class file.
 
 The gizmos will only be processed on the scene view camera, and the default MainCamera. To change this, you can specify using the static property for `Camera` in the `Gizmo` class:
 ```cs

--- a/Runtime/Constants.cs
+++ b/Runtime/Constants.cs
@@ -1,4 +1,4 @@
-﻿namespace Popcron.Gizmos
+﻿namespace Popcron
 {
     public class Constants
     {

--- a/Runtime/DrawInfo.cs
+++ b/Runtime/DrawInfo.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using UnityEngine;
 
-namespace Popcron.Gizmos
+namespace Popcron
 {
     [Serializable]
     public class DrawInfo

--- a/Runtime/Drawer.cs
+++ b/Runtime/Drawer.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Popcron.Gizmos
+namespace Popcron
 {
     public abstract class Drawer
     {

--- a/Runtime/Drawers/CubeDrawer.cs
+++ b/Runtime/Drawers/CubeDrawer.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace Popcron.Gizmos
+namespace Popcron
 {
     public class CubeDrawer : Drawer
     {

--- a/Runtime/Drawers/LineDrawer.cs
+++ b/Runtime/Drawers/LineDrawer.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace Popcron.Gizmos
+namespace Popcron
 {
     public class LineDrawer : Drawer
     {

--- a/Runtime/Drawers/PolygonDrawer.cs
+++ b/Runtime/Drawers/PolygonDrawer.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace Popcron.Gizmos
+namespace Popcron
 {
     public class PolygonDrawer : Drawer
     {

--- a/Runtime/Drawers/SquareDrawer.cs
+++ b/Runtime/Drawers/SquareDrawer.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-namespace Popcron.Gizmos
+namespace Popcron
 {
     public class SquareDrawer : Drawer
     {

--- a/Runtime/Element.cs
+++ b/Runtime/Element.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Popcron.Gizmos
+namespace Popcron
 {
     [Serializable]
     internal class Element

--- a/Runtime/Gizmos.cs
+++ b/Runtime/Gizmos.cs
@@ -2,9 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-using Popcron.Gizmos;
-
-namespace Popcron.Gizmos
+namespace Popcron
 {
     public class Gizmos
     {

--- a/Runtime/Gizmos.cs
+++ b/Runtime/Gizmos.cs
@@ -4,240 +4,243 @@ using UnityEngine;
 
 using Popcron.Gizmos;
 
-public class Gizmos
+namespace Popcron
 {
-    private static bool? enabled = null;
-    private static bool? cull = null;
-    private static Vector3? offset = null;
-    private static Camera camera = null;
-
-    /// <summary>
-    /// Toggles wether the gizmos could be drawn or not
-    /// </summary>
-    public static bool Enabled
+    public class Gizmos
     {
-        get
-        {
-            if (enabled == null)
-            {
-                enabled = PlayerPrefs.GetInt(Application.buildGUID + Constants.UniqueIdentifier + ".Enabled", 1) == 1;
-            }
+        private static bool? enabled = null;
+        private static bool? cull = null;
+        private static Vector3? offset = null;
+        private static Camera camera = null;
 
-            return enabled.Value;
-        }
-        set
+        /// <summary>
+        /// Toggles wether the gizmos could be drawn or not
+        /// </summary>
+        public static bool Enabled
         {
-            if (enabled != value)
+            get
             {
-                enabled = value;
-                PlayerPrefs.SetInt(Application.buildGUID + Constants.UniqueIdentifier + ".Enabled", value ? 1 : 0);
-            }
-        }
-    }
-
-	/// <summary>
-    /// The camera to use when rendering, uses the MainCamera by default
-    /// </summary>
-    public static Camera Camera
-    {
-        get
-        {
-            if (camera == null)
-            {
-                camera = Camera.main;
-            }
-
-            return camera;
-        }
-        set
-        {
-            camera = value;
-        }
-    }
-
-    /// <summary>
-    /// Should the camera not draw elements that are not visible?
-    /// </summary>
-    public static bool Cull
-    {
-        get
-        {
-            if (cull == null)
-            {
-                cull = PlayerPrefs.GetInt(Application.buildGUID + Constants.UniqueIdentifier + ".Cull", 1) == 1;
-            }
-
-            return cull.Value;
-        }
-        set
-        {
-            if (cull != value)
-            {
-                cull = value;
-                PlayerPrefs.SetInt(Application.buildGUID + Constants.UniqueIdentifier + ".Cull", value ? 1 : 0);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Global offset for all points. Default is (0, 0, 0)
-    /// </summary>
-    public static Vector3 Offset
-    {
-        get
-        {
-            const string Delim = ",";
-            if (offset == null)
-            {
-                string data = PlayerPrefs.GetString(Application.buildGUID + Constants.UniqueIdentifier, 0 + Delim + 0 + Delim + 0);
-                int indexOf = data.IndexOf(Delim);
-                int lastIndexOf = data.LastIndexOf(Delim);
-                if (indexOf + lastIndexOf > 0)
+                if (enabled == null)
                 {
-                    string[] arr = data.Split(Delim[0]);
-                    offset = new Vector3(float.Parse(arr[0]), float.Parse(arr[1]), float.Parse(arr[2]));
+                    enabled = PlayerPrefs.GetInt(Application.buildGUID + Constants.UniqueIdentifier + ".Enabled", 1) == 1;
                 }
-                else
+
+                return enabled.Value;
+            }
+            set
+            {
+                if (enabled != value)
                 {
-                    return Vector3.zero;
+                    enabled = value;
+                    PlayerPrefs.SetInt(Application.buildGUID + Constants.UniqueIdentifier + ".Enabled", value ? 1 : 0);
                 }
             }
-
-            return offset.Value;
         }
-        set
+
+        /// <summary>
+        /// The camera to use when rendering, uses the MainCamera by default
+        /// </summary>
+        public static Camera Camera
         {
-            const string Delim = ",";
-            if (offset != value)
+            get
             {
-                offset = value;
-                PlayerPrefs.SetString(Application.buildGUID + Constants.UniqueIdentifier, value.x + Delim + value.y + Delim + value.y);
+                if (camera == null)
+                {
+                    camera = Camera.main;
+                }
+
+                return camera;
+            }
+            set
+            {
+                camera = value;
             }
         }
-    }
 
-    /// <summary>
-    /// Draws an element onto the screen
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    /// <param name="info"></param>
-    public static void Draw<T>(Color? color, bool dashed, params object[] args) where T : Drawer
-    {
-        if (!Enabled) return;
-
-        Drawer drawer = Drawer.Get<T>();
-        if (drawer != null)
+        /// <summary>
+        /// Should the camera not draw elements that are not visible?
+        /// </summary>
+        public static bool Cull
         {
-            Camera currentCamera = GizmosInstance.currentCamera;
-            Vector3[] points = drawer.Draw(args);
+            get
+            {
+                if (cull == null)
+                {
+                    cull = PlayerPrefs.GetInt(Application.buildGUID + Constants.UniqueIdentifier + ".Cull", 1) == 1;
+                }
 
-			if (Cull)
-			{
-				bool visible = false;
-				for (int i = 0; i < points.Length; i++)
-				{
-                    //no current camera, assume its visible
-                    if (currentCamera == null)
+                return cull.Value;
+            }
+            set
+            {
+                if (cull != value)
+                {
+                    cull = value;
+                    PlayerPrefs.SetInt(Application.buildGUID + Constants.UniqueIdentifier + ".Cull", value ? 1 : 0);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Global offset for all points. Default is (0, 0, 0)
+        /// </summary>
+        public static Vector3 Offset
+        {
+            get
+            {
+                const string Delim = ",";
+                if (offset == null)
+                {
+                    string data = PlayerPrefs.GetString(Application.buildGUID + Constants.UniqueIdentifier, 0 + Delim + 0 + Delim + 0);
+                    int indexOf = data.IndexOf(Delim);
+                    int lastIndexOf = data.LastIndexOf(Delim);
+                    if (indexOf + lastIndexOf > 0)
                     {
-                        visible = true;
-                        break;
+                        string[] arr = data.Split(Delim[0]);
+                        offset = new Vector3(float.Parse(arr[0]), float.Parse(arr[1]), float.Parse(arr[2]));
+                    }
+                    else
+                    {
+                        return Vector3.zero;
+                    }
+                }
+
+                return offset.Value;
+            }
+            set
+            {
+                const string Delim = ",";
+                if (offset != value)
+                {
+                    offset = value;
+                    PlayerPrefs.SetString(Application.buildGUID + Constants.UniqueIdentifier, value.x + Delim + value.y + Delim + value.y);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Draws an element onto the screen
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="info"></param>
+        public static void Draw<T>(Color? color, bool dashed, params object[] args) where T : Drawer
+        {
+            if (!Enabled) return;
+
+            Drawer drawer = Drawer.Get<T>();
+            if (drawer != null)
+            {
+                Camera currentCamera = GizmosInstance.currentCamera;
+                Vector3[] points = drawer.Draw(args);
+
+                if (Cull)
+                {
+                    bool visible = false;
+                    for (int i = 0; i < points.Length; i++)
+                    {
+                        //no current camera, assume its visible
+                        if (currentCamera == null)
+                        {
+                            visible = true;
+                            break;
+                        }
+
+                        //frustrum cull using the current camera
+                        Vector3 p = currentCamera.WorldToScreenPoint(points[i]);
+                        if (p.x >= 0 && p.y >= 0 && p.x <= Screen.width && p.y <= Screen.height && p.z >= 0)
+                        {
+                            visible = true;
+                            break;
+                        }
                     }
 
-                    //frustrum cull using the current camera
-                    Vector3 p = currentCamera.WorldToScreenPoint(points[i]);
-					if (p.x >= 0 && p.y >= 0 && p.x <= Screen.width && p.y <= Screen.height && p.z >= 0)
-					{
-						visible = true;
-						break;
-					}
-				}
+                    if (!visible)
+                    {
+                        return;
+                    }
+                }
 
-				if (!visible)
-				{
-					return;
-				}
-			}
-
-            GizmosInstance.Add(points, color, dashed);
+                GizmosInstance.Add(points, color, dashed);
+            }
         }
-    }
 
-    /// <summary>
-    /// Draw line in world space
-    /// </summary>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    /// <param name="color"></param>
-    public static void Line(Vector3 a, Vector3 b, Color? color = null, bool dashed = false)
-    {
-        Draw<LineDrawer>(color, dashed, a, b);
-    }
+        /// <summary>
+        /// Draw line in world space
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="color"></param>
+        public static void Line(Vector3 a, Vector3 b, Color? color = null, bool dashed = false)
+        {
+            Draw<LineDrawer>(color, dashed, a, b);
+        }
 
-    /// <summary>
-    /// Draw square in world space
-    /// </summary>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    /// <param name="color"></param>
-    public static void Square(Vector2 position, Vector2 size, Color? color = null, bool dashed = false)
-    {
-        Draw<SquareDrawer>(color, dashed, position, Quaternion.identity, size * 0.5f);
-    }
+        /// <summary>
+        /// Draw square in world space
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="color"></param>
+        public static void Square(Vector2 position, Vector2 size, Color? color = null, bool dashed = false)
+        {
+            Draw<SquareDrawer>(color, dashed, position, Quaternion.identity, size * 0.5f);
+        }
 
-    /// <summary>
-    /// Draw square in world space with float diameter parameter
-    /// </summary>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    /// <param name="color"></param>
-    public static void Square(Vector2 position, float diameter, Color? color = null, bool dashed = false)
-    {
-        Draw<SquareDrawer>(color, dashed, position, Quaternion.identity, Vector2.one * diameter * 0.5f);
-    }
+        /// <summary>
+        /// Draw square in world space with float diameter parameter
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="color"></param>
+        public static void Square(Vector2 position, float diameter, Color? color = null, bool dashed = false)
+        {
+            Draw<SquareDrawer>(color, dashed, position, Quaternion.identity, Vector2.one * diameter * 0.5f);
+        }
 
-    /// <summary>
-    /// Draw square in world space with a rotation parameter
-    /// </summary>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    /// <param name="color"></param>
-    public static void Square(Vector2 position, Quaternion rotation, Vector2 size, Color? color = null, bool dashed = false)
-    {
-        Draw<SquareDrawer>(color, dashed, position, rotation, size * 0.5f);
-    }
+        /// <summary>
+        /// Draw square in world space with a rotation parameter
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        /// <param name="color"></param>
+        public static void Square(Vector2 position, Quaternion rotation, Vector2 size, Color? color = null, bool dashed = false)
+        {
+            Draw<SquareDrawer>(color, dashed, position, rotation, size * 0.5f);
+        }
 
-    /// <summary>
-    /// Draws a cube in world space
-    /// </summary>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    public static void Cube(Vector3 position, Quaternion rotation, Vector3 size, Color? color = null, bool dashed = false)
-    {
-        Draw<CubeDrawer>(color, dashed, position, rotation, size * 0.5f);
-    }
+        /// <summary>
+        /// Draws a cube in world space
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        public static void Cube(Vector3 position, Quaternion rotation, Vector3 size, Color? color = null, bool dashed = false)
+        {
+            Draw<CubeDrawer>(color, dashed, position, rotation, size * 0.5f);
+        }
 
-    /// <summary>
-    /// Draws a circle in world space with the main camera position
-    /// </summary>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    public static void Circle(Vector3 position, float radius, Color? color = null, bool dashed = false)
-    {
-        int points = 16;
-        float offset = 0f;
-        Quaternion rotation = Camera.transform.rotation;
-        Draw<PolygonDrawer>(color, dashed, position, points, radius, offset, rotation);
-    }
+        /// <summary>
+        /// Draws a circle in world space with the main camera position
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        public static void Circle(Vector3 position, float radius, Color? color = null, bool dashed = false)
+        {
+            int points = 16;
+            float offset = 0f;
+            Quaternion rotation = Camera.transform.rotation;
+            Draw<PolygonDrawer>(color, dashed, position, points, radius, offset, rotation);
+        }
 
-    /// <summary>
-    /// Draws a circle in world space with a specified rotation
-    /// </summary>
-    /// <param name="a"></param>
-    /// <param name="b"></param>
-    public static void Circle(Vector3 position, float radius, Quaternion rotation, Color? color = null, bool dashed = false)
-    {
-        int points = 16;
-        float offset = 0f;
-        Draw<PolygonDrawer>(color, dashed, position, points, radius, offset, rotation);
+        /// <summary>
+        /// Draws a circle in world space with a specified rotation
+        /// </summary>
+        /// <param name="a"></param>
+        /// <param name="b"></param>
+        public static void Circle(Vector3 position, float radius, Quaternion rotation, Color? color = null, bool dashed = false)
+        {
+            int points = 16;
+            float offset = 0f;
+            Draw<PolygonDrawer>(color, dashed, position, points, radius, offset, rotation);
+        }
     }
 }

--- a/Runtime/Gizmos.cs
+++ b/Runtime/Gizmos.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 using Popcron.Gizmos;
 
-namespace Popcron
+namespace Popcron.Gizmos
 {
     public class Gizmos
     {

--- a/Runtime/GizmosInstance.cs
+++ b/Runtime/GizmosInstance.cs
@@ -147,7 +147,7 @@ namespace Popcron.Gizmos
             {
                 allow = true;
             }
-            else if (camera == global::Gizmos.Camera)
+            else if (camera == Gizmos.Camera)
             {
                 allow = true;
             }
@@ -155,7 +155,7 @@ namespace Popcron.Gizmos
             if (!allow) return;
 
 			currentCamera = camera;
-            Vector3 offset = global::Gizmos.Offset;
+            Vector3 offset = Gizmos.Offset;
             Material.SetPass(0);
 
             GL.PushMatrix();

--- a/Runtime/GizmosInstance.cs
+++ b/Runtime/GizmosInstance.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 
-namespace Popcron.Gizmos
+namespace Popcron
 {
     [ExecuteInEditMode]
     [AddComponentMenu("")]


### PR DESCRIPTION
> The package uses the same class name as the built-in gizmo class, if you'd like to specify the built-in one, explictly call UntiyEngine.Gizmos.X(). On the other hand, you can also point to this package's gizmo class with global::Gizmos.

I believe having global class in a Package is a really bad idea. After just trying to experiment with it, I started having conflicts in our other scripts that referenced UnityEngine's Gizmos.
As I believe Packages shouldn't require changing other source code just to use them, I suggest this fix - change Package namespace from `Popcron.Gizmos` to simply `Popcron`, add Gizmos inside this namespace and reference it in scripts using full namespace, e.g. `Popcron.Gizmos.Cube(transform.position, transform.rotation, transform.lossyScale)`

@popcron, if you don't like it, then please fix this issue otherwise.