### PR TITLE
Gizmos aren't rendered when RenderPipeline is set

### DIFF
--- a/Runtime/GizmosInstance.cs
+++ b/Runtime/GizmosInstance.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Rendering;
 
 namespace Popcron
 {
@@ -131,12 +132,31 @@ namespace Popcron
                 queue[i] = new Element();
             }
 
-            Camera.onPostRender += OnRendered;
+            if (GraphicsSettings.renderPipelineAsset == null)
+            {
+                Camera.onPostRender += OnRendered;
+            }
+            else
+            {
+                RenderPipelineManager.endCameraRendering += OnRendered;
+            }
         }
 
         private void OnDisable()
         {
-            Camera.onPostRender -= OnRendered;
+            if (GraphicsSettings.renderPipelineAsset == null)
+            {
+                Camera.onPostRender -= OnRendered;
+            }
+            else
+            {
+                RenderPipelineManager.endCameraRendering -= OnRendered;
+            }
+        }
+
+        private void OnRendered(ScriptableRenderContext context, Camera camera)
+        {
+            OnRendered(camera);
         }
 
         private void OnRendered(Camera camera)


### PR DESCRIPTION
We use [LWRP](https://unity.com/lightweight-render-pipeline) in our project and Gizmos aren't rendered with it. As I found out, it's because `Camera.OnPostRender` callback [was removed](https://forum.unity.com/threads/feedback-wanted-scriptable-render-pipelines.470095/page-8#post-3408481) in Scriptable Render Pipelines.

Here's a fix for it.

Subscribed to new event in [RenderPipelineManager](https://docs.unity3d.com/2019.1/Documentation/ScriptReference/Rendering.RenderPipelineManager.html)