### PR TITLE
 Fix compatibility issues with legacy projects without Scriptable Render Pipeline package installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Gizmos.Camera = myCamera;
 
 The alternative is to make a global class with the same name that redirects all of its calls to Popcron.Gizmos. The downside to this is that you will need to be explicit when calling the UnityEngine.Gizmos class. Choose your poison.
 
+When using the legacy pipeline in a project without the Scriptable Rendering Pipeline package installed, you need to set the `UNITY_LEGACY_PIPELINE` preprocessor directive in the Project Settings > Player > Scripting Define Symbols.
+
 ## FAQ
 - **What namespace?** 'Popcron'
 - **Does it work in builds?** Yes

--- a/Runtime/GizmosInstance.cs
+++ b/Runtime/GizmosInstance.cs
@@ -7,7 +7,7 @@ using UnityEngine.SceneManagement;
 using UnityEditor.SceneManagement;
 #endif
 
-#if UNITY_2018_4
+#if !UNITY_2019_1_OR_NEWER
 using System;
 
 public struct ScriptableRenderContext {}

--- a/Runtime/GizmosInstance.cs
+++ b/Runtime/GizmosInstance.cs
@@ -7,6 +7,18 @@ using UnityEngine.SceneManagement;
 using UnityEditor.SceneManagement;
 #endif
 
+#if UNITY_LEGACY_PIPELINE
+using System;
+
+public struct ScriptableRenderContext {}
+
+public static class RenderPipelineManager
+{
+    public static event Action<ScriptableRenderContext, Camera> endCameraRendering;
+}
+
+#endif
+
 namespace Popcron
 {
     [ExecuteInEditMode]

--- a/Runtime/GizmosInstance.cs
+++ b/Runtime/GizmosInstance.cs
@@ -7,7 +7,7 @@ using UnityEngine.SceneManagement;
 using UnityEditor.SceneManagement;
 #endif
 
-#if UNITY_LEGACY_PIPELINE
+#if UNITY_2018_4
 using System;
 
 public struct ScriptableRenderContext {}


### PR DESCRIPTION
This pull request adds empty definitions for the Scriptable Render Pipeline package classes and structs to fix compilation errors when it's not installed in the project. It also updates the README.md in order to warn about this optional configuration.