### PR TITLE
Downgrade to C# 8

### DIFF
--- a/Editor/Updater.cs
+++ b/Editor/Updater.cs
@@ -27,7 +27,7 @@ public class Updater : Editor
 
     private static async Task<bool> IsUpdateAvailable()
     {
-        Uri uri = new ("https://www.google.com/");
+        Uri uri = new Uri("https://www.google.com/");
         IPStatus result = await Task.Run(() => IsHostReachable(uri.Host));
         if (result == IPStatus.Success)
         {
@@ -54,7 +54,7 @@ public class Updater : Editor
             return IPStatus.DestinationUnreachable;
         }
 
-        Ping pinger = new();
+        Ping pinger = new Ping();
         try
         {
             // Wait at most 2 seconds for the ICMP echo reply message


### PR DESCRIPTION
Unity has supported C# 9.0 since [2021.2](https://docs.unity3d.com/2021.2/Documentation/Manual/CSharpCompiler.html). Therefore [Target-typed new expressions](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/target-typed-new) is not available in 2020 LTS.

![image](https://user-images.githubusercontent.com/19392641/226603776-ae310f67-41f3-4744-9a92-54b811239298.png)
